### PR TITLE
fix: prevent re-requesting opponents

### DIFF
--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -215,6 +215,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         characterInArena(characterID)
         isOwnedCharacter(characterID)
     {
+        require(!hasPendingDuel(characterID), "Opponent already requested");
         _assignOpponent(characterID);
     }
 

--- a/test/pvp-arena.js
+++ b/test/pvp-arena.js
@@ -442,6 +442,26 @@ contract("PvpArena", (accounts) => {
       });
     });
 
+    describe("with pending duel", () => {
+      let character0ID;
+
+      beforeEach(async () => {
+        character0ID = await createCharacterInPvpTier(accounts[1], 2, "000");
+        character1ID = await createCharacterInPvpTier(accounts[2], 2, "111");
+        character2ID = await createCharacterInPvpTier(accounts[2], 2, "222");
+
+        await time.increase(await pvpArena.unattackableSeconds());
+      });
+
+      it("reverts", async () => {
+        await pvpArena.requestOpponent(character0ID, { from: accounts[1] });
+        await expectRevert(
+          pvpArena.requestOpponent(character0ID, { from: accounts[1] }),
+          "Opponent already requested"
+        );
+      });
+    });
+
     describe("finding opponents", () => {
       let character0ID;
       let character2ID;


### PR DESCRIPTION
* Prevents re-requesting opponents when a duel is pending
* Updates tests to consider this edge-case