### PR TITLE
Feat/pvp  season reward distribution

### DIFF
--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -908,7 +908,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         ].add(amountToTransfer);
     }
 
-    /// @dev allows a player to withdraw their withdrawable funds
+    /// @dev allows a player to withdraw their ranking earnings
     function withdrawRankedRewards() external {
         uint256 amountToTransfer = _rankingEarningsByPlayer[msg.sender];
 
@@ -919,6 +919,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         }
     }
 
+    /// @dev returns ranked prize percentages distribution
     function getPrizePercentages() public view returns (uint256[] memory) {
         return prizePercentages;
     }

--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -853,6 +853,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
             if (_fightersByTier[i].length() == 0) {
                 continue;
             }
+
             uint256 difference;
 
             if (_rankingByTier[i].length <= prizePercentages.length) {
@@ -873,7 +874,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
                     j++
                 ) {
                     excessPercentage = excessPercentage.add(
-                        prizePercentages[prizePercentages.length - difference]
+                        prizePercentages[j]
                     );
                 }
 
@@ -899,12 +900,8 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         uint256 pool
     ) private {
         uint256 percentage = prizePercentages[position];
-
+        uint256 amountToTransfer = (pool.mul(percentage)).div(100);
         address playerToTransfer = characters.ownerOf(characterID);
-
-        uint256 amountToTransfer;
-
-        amountToTransfer = (pool.mul(percentage)).div(100);
 
         _rankingEarningsByPlayer[playerToTransfer] = _rankingEarningsByPlayer[
             playerToTransfer

--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -846,8 +846,8 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         processLoser(characterID);
     }
 
-    /// @dev distributes the ranking rewards pool to top players
-    function distributeSeasonRewards() external restricted {
+    /// @dev assigns the ranking rewards pool to top players
+    function assignRankedRewards() external restricted {
         // Note: Loops over 15 tiers. Should not be reachable anytime in the foreseeable future.
         for (uint8 i = 0; i <= 15; i++) {
             if (_fightersByTier[i].length() == 0) {
@@ -867,7 +867,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
                 uint256 excessPercentage;
                 address topOnePlayer = characters.ownerOf(_rankingByTier[i][0]);
 
-                // Note: We accumulate excessive percentage.
+                // Note: We accumulate excess percentage.
                 for (
                     uint256 j = prizePercentages.length - difference;
                     j < prizePercentages.length;
@@ -887,9 +887,12 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
             }
 
             // Note: We assign rewards normally to all possible players.
-            for (uint8 h = 0; h < (prizePercentages.length) - difference; h++) {
+            for (uint8 h = 0; h < prizePercentages.length - difference; h++) {
                 _assignRewards(_rankingByTier[i][h], h, _rankingsPoolByTier[i]);
             }
+
+            // Note: We reset ranking prize pools.
+            _rankingsPoolByTier[i] = 0;
         }
     }
 

--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -71,11 +71,17 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
     uint8 public losingPoints;
     /// @dev amount of players that are considered for the top ranking
     uint8 private _maxCharactersPerRanking;
+    /// @dev percentages of ranked prize distribution by fighter rank (represented as index)
+    uint256[] private _prizePercentages;
 
     /// @dev Fighter by characterID
     mapping(uint256 => Fighter) public fighterByCharacter;
     /// @dev Active duel by characterID currently attacking
     mapping(uint256 => Duel) public duelByAttacker;
+    /// @dev ranking points by character
+    mapping(uint256 => uint256) public characterRankingPoints;
+    /// @dev funds available for withdrawal by address
+    mapping(address => uint256) private _rankingEarningsByPlayer;
     /// @dev last time a character was involved in activity that makes it untattackable
     mapping(uint256 => uint256) private _lastActivityByCharacter;
     /// @dev IDs of characters available by tier (1-10, 11-20, etc...)
@@ -94,8 +100,6 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
     mapping(uint256 => uint256) private _duelEarningsByCharacter;
     /// @dev ranking by tier
     mapping(uint8 => uint256[]) private _rankingByTier;
-    /// @dev ranking points by character
-    mapping(uint256 => uint256) public characterRankingPoints;
 
     event NewDuel(
         uint256 indexed attacker,
@@ -118,6 +122,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         );
         _;
     }
+
     modifier isOwnedCharacter(uint256 characterID) {
         require(
             characters.ownerOf(characterID) == msg.sender,
@@ -189,6 +194,9 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         winningPoints = 5;
         losingPoints = 3;
         _maxCharactersPerRanking = 4;
+        _prizePercentages.push(60);
+        _prizePercentages.push(30);
+        _prizePercentages.push(10);
     }
 
     /// @notice enter the arena with a character, a weapon and optionally a shield
@@ -226,7 +234,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         skillToken.transferFrom(msg.sender, address(this), wager);
     }
 
-    /// @dev attempts to find an opponent for a character. If a battle is still pending, it charges a penalty and re-rolls the opponent
+    /// @dev attempts to find an opponent for a character
     function requestOpponent(uint256 characterID)
         external
         characterInArena(characterID)
@@ -670,7 +678,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         _lastActivityByCharacter[characterID] = block.timestamp;
     }
 
-    /// @dev function where admins can seta character's ranking points
+    /// @dev function where admins can set a character's ranking points
     function setRankingPoints(uint256 characterID, uint8 newRankingPoints)
         public
         restricted
@@ -835,5 +843,78 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         characterRankingPoints[characterID] = 0;
         //this is not final, but processing the loser will update the ranks leaving this player in the 4th position, which will be quickly replaced by other players
         processLoser(characterID);
+    }
+
+    /// @dev distributes the ranking rewards pool to top players
+    function distributeSeasonRewards() external restricted {
+        // Note: Loops over 15 tiers. Should not be reachable anytime in the foreseeable future.
+        for (uint8 i = 0; i <= 15; i++) {
+            if (_fightersByTier[i].length() == 0) {
+                continue;
+            }
+            uint256 difference = _prizePercentages.length -
+                _rankingByTier[i].length;
+
+            // Note: If there are less players than top positions, excess is transferred to top 1.
+            if (_rankingByTier[i].length < _prizePercentages.length) {
+                uint256 excessPercentage;
+                address topOnePlayer = characters.ownerOf(_rankingByTier[i][0]);
+
+                // Note: We accumulate excessive percentage.
+                for (
+                    uint256 j = difference;
+                    j < _prizePercentages.length;
+                    j++
+                ) {
+                    excessPercentage = excessPercentage.add(
+                        _prizePercentages[_prizePercentages.length - difference]
+                    );
+                }
+
+                // Note: We assign excessive rewards to top 1 player.
+                _rankingEarningsByPlayer[
+                    topOnePlayer
+                ] = _rankingEarningsByPlayer[topOnePlayer].add(
+                    (_rankingsPoolByTier[i].mul(excessPercentage)).div(100)
+                );
+            }
+
+            // Note: We assign rewards normally to all possible players.
+            for (uint8 h = 0; h < _prizePercentages.length - difference; h++) {
+                _assignRewards(
+                    _rankingByTier[i][h],
+                    h + 1,
+                    _rankingsPoolByTier[i]
+                );
+            }
+        }
+    }
+
+    /// @dev increases a players withdrawable funds depending on their position in the ranked leaderboard
+    function _assignRewards(
+        uint256 characterID,
+        uint8 position,
+        uint256 pool
+    ) private {
+        uint256 percentage = _prizePercentages[position];
+        address playerToTransfer = characters.ownerOf(characterID);
+        uint256 amountToTransfer;
+
+        amountToTransfer = (pool.mul(percentage)).div(100);
+
+        _rankingEarningsByPlayer[playerToTransfer] = _rankingEarningsByPlayer[
+            playerToTransfer
+        ].add(amountToTransfer);
+    }
+
+    /// @dev allows a player to withdraw their withdrawable funds
+    function withdrawRankedRewards() external {
+        uint256 amountToTransfer = _rankingEarningsByPlayer[msg.sender];
+
+        if (amountToTransfer > 0) {
+            _rankingEarningsByPlayer[msg.sender] = 0;
+
+            skillToken.safeTransfer(msg.sender, amountToTransfer);
+        }
     }
 }

--- a/test/pvp-arena.js
+++ b/test/pvp-arena.js
@@ -2147,7 +2147,7 @@ contract("PvpArena", (accounts) => {
     });
   });
 
-  describe("#distributeSeasonRewards", () => {
+  describe("#assignRankedRewards", () => {
     // These tests assume prizes will be distributed amongst at least 2 players and at most 4 players.
     beforeEach(async () => {
       character1ID = await createCharacterInPvpTier(accounts[1], 1);
@@ -2190,7 +2190,7 @@ contract("PvpArena", (accounts) => {
       const balanceThree = await skillToken.balanceOf(accounts[3]);
       const balanceFour = await skillToken.balanceOf(accounts[4]);
 
-      await pvpArena.distributeSeasonRewards({ from: accounts[0] });
+      await pvpArena.assignRankedRewards({ from: accounts[0] });
 
       await pvpArena.withdrawRankedRewards({ from: accounts[1] });
       await pvpArena.withdrawRankedRewards({ from: accounts[2] });
@@ -2253,7 +2253,7 @@ contract("PvpArena", (accounts) => {
       const balanceOne = await skillToken.balanceOf(accounts[1]);
       const balanceTwo = await skillToken.balanceOf(accounts[2]);
 
-      await pvpArena.distributeSeasonRewards({ from: accounts[0] });
+      await pvpArena.assignRankedRewards({ from: accounts[0] });
 
       await pvpArena.withdrawRankedRewards({ from: accounts[1] });
       await pvpArena.withdrawRankedRewards({ from: accounts[2] });
@@ -2292,6 +2292,35 @@ contract("PvpArena", (accounts) => {
 
       expect(isNewBalanceOneValid).to.equal(true);
       expect(isNewBalanceTwoValid).to.equal(true);
+    });
+
+    it("resets ranking prize pools", async () => {
+      const balanceOne = await skillToken.balanceOf(accounts[1]);
+      const balanceTwo = await skillToken.balanceOf(accounts[2]);
+
+      await pvpArena.assignRankedRewards({ from: accounts[0] });
+
+      await pvpArena.withdrawRankedRewards({ from: accounts[1] });
+      await pvpArena.withdrawRankedRewards({ from: accounts[2] });
+
+      const newerBalanceOne = await skillToken.balanceOf(accounts[1]);
+      const newerBalanceTwo = await skillToken.balanceOf(accounts[2]);
+
+      await pvpArena.assignRankedRewards({ from: accounts[0] });
+
+      const newestBalanceOne = await skillToken.balanceOf(accounts[1]);
+      const newestBalanceTwo = await skillToken.balanceOf(accounts[2]);
+
+      const didBalanceOneGrow = balanceOne < newerBalanceOne;
+      const didBalanceTwoGrow = balanceTwo < newerBalanceTwo;
+
+      const didBalanceOneGrowAgain = newerBalanceOne < newestBalanceOne;
+      const didBalanceTwoGrowAgain = newerBalanceTwo < newestBalanceTwo;
+
+      expect(didBalanceOneGrow).to.equal(true);
+      expect(didBalanceTwoGrow).to.equal(true);
+      expect(didBalanceOneGrowAgain).to.equal(false);
+      expect(didBalanceTwoGrowAgain).to.equal(false);
     });
   });
 });

--- a/test/pvp-arena.js
+++ b/test/pvp-arena.js
@@ -71,6 +71,17 @@ contract("PvpArena", (accounts) => {
       accounts[3],
       web3.utils.toWei("1", "kether")
     );
+    await skillToken.transferFrom(
+      skillToken.address,
+      accounts[4],
+      web3.utils.toWei("1", "kether")
+    );
+    await skillToken.transferFrom(
+      skillToken.address,
+      accounts[5],
+      web3.utils.toWei("1", "kether")
+    );
+
     await pvpArena.grantRole(await pvpArena.GAME_ADMIN(), accounts[0]);
     await characters.grantRole(await characters.GAME_ADMIN(), accounts[0]);
     await characters.grantRole(await characters.NO_OWNED_LIMIT(), accounts[1]);
@@ -912,6 +923,7 @@ contract("PvpArena", (accounts) => {
       it("should subtract the penalty from the refunded amount");
     });
   });
+
   describe("#performDuel", async () => {
     describe("happy path", () => {
       describe("attacker wins", () => {
@@ -1805,6 +1817,7 @@ contract("PvpArena", (accounts) => {
       });
     });
   });
+
   describe("rankingBehaviour", () => {
     describe("entering the arena ", () => {
       let character1ID;
@@ -1815,6 +1828,7 @@ contract("PvpArena", (accounts) => {
       let character6ID;
       let weapon1ID;
       let weapon2ID;
+
       it("should fill the rank with the first 4 players", async () => {
         character1ID = await createCharacterInPvpTier(accounts[1], 2, "222");
         character2ID = await createCharacterInPvpTier(accounts[1], 2, "222");
@@ -1831,6 +1845,7 @@ contract("PvpArena", (accounts) => {
         expect(characterTier[3].toString()).to.equal(character5ID.toString());
       });
     });
+
     describe("after the fight", () => {
       it("update the ranks of both the winner and the loser and add/subtract points respectively", async () => {
         const winningPoints = await pvpArena.winningPoints();
@@ -1923,6 +1938,7 @@ contract("PvpArena", (accounts) => {
           loserPreviousRankPoints.sub(losingPoints).toString()
         );
       });
+
       it("should update the player if he is not within the top 4 and has a higher score than the 4th ranked player", async () => {
         weapon1ID = await helpers.createWeapon(
           accounts[2],
@@ -1995,6 +2011,7 @@ contract("PvpArena", (accounts) => {
         // expect the last character to be the first one, climibing through the entire ladder
         expect(playerTier[0].toString()).to.equal(character6ID).toString();
       });
+
       it("should process the winner and the loser with only 2 players inside the tier", async () => {
         weapon1ID = await helpers.createWeapon(
           accounts[2],
@@ -2132,6 +2149,154 @@ contract("PvpArena", (accounts) => {
         expect(isCharacterInTier).to.equal(false);
         expect(playerTier[3].toString()).to.equal(character1ID.toString());
       });
+    });
+  });
+
+  describe.only("#distributeSeasonRewards", () => {
+    // These tests assume prizes will be distributed amongst at least 2 players and at most 4 players.
+    beforeEach(async () => {
+      character1ID = await createCharacterInPvpTier(accounts[1], 1);
+      character2ID = await createCharacterInPvpTier(accounts[2], 1);
+
+      await pvpArena.setRankingPoints(character1ID, 100, {
+        from: accounts[0],
+      });
+      await pvpArena.setRankingPoints(character2ID, 80, {
+        from: accounts[0],
+      });
+
+      await time.increase(await pvpArena.unattackableSeconds());
+
+      // We execute a duel so theres a prize pool
+      await pvpArena.requestOpponent(character1ID, {
+        from: accounts[1],
+      });
+
+      await pvpArena.performDuel(character1ID, {
+        from: accounts[1],
+      });
+    });
+
+    it("distributes rewards correctly to top characters' owners", async () => {
+      const prizePercentages = await pvpArena.getPrizePercentages();
+
+      const character3ID = await createCharacterInPvpTier(accounts[3], 1);
+      const character4ID = await createCharacterInPvpTier(accounts[4], 1);
+
+      await pvpArena.setRankingPoints(character3ID, 60, {
+        from: accounts[0],
+      });
+      await pvpArena.setRankingPoints(character4ID, 40, {
+        from: accounts[0],
+      });
+
+      const balanceOne = await skillToken.balanceOf(accounts[1]);
+      const balanceTwo = await skillToken.balanceOf(accounts[2]);
+      const balanceThree = await skillToken.balanceOf(accounts[3]);
+      const balanceFour = await skillToken.balanceOf(accounts[4]);
+
+      await pvpArena.distributeSeasonRewards({ from: accounts[0] });
+
+      await pvpArena.withdrawRankedRewards({ from: accounts[1] });
+      await pvpArena.withdrawRankedRewards({ from: accounts[2] });
+      await pvpArena.withdrawRankedRewards({ from: accounts[3] });
+      await pvpArena.withdrawRankedRewards({ from: accounts[4] });
+
+      const newBalanceOne = await skillToken.balanceOf(accounts[1]);
+      const newBalanceTwo = await skillToken.balanceOf(accounts[2]);
+      const newBalanceThree = await skillToken.balanceOf(accounts[3]);
+      const newBalanceFour = await skillToken.balanceOf(accounts[4]);
+
+      const expectedPlayerOneWithdrawal = newBalanceOne.sub(balanceOne);
+      const expectedPlayerTwoWithdrawal = newBalanceTwo.sub(balanceTwo);
+      const expectedPlayerThreeWithdrawal = newBalanceThree.sub(balanceThree);
+      const expectedPlayerFourWithdrawal = newBalanceFour.sub(balanceFour);
+
+      const totalPool = expectedPlayerOneWithdrawal
+        .add(expectedPlayerTwoWithdrawal)
+        .add(expectedPlayerThreeWithdrawal)
+        .add(expectedPlayerFourWithdrawal);
+
+      const isNewBalanceOneValid =
+        newBalanceOne.toString() ===
+        balanceOne
+          .add(totalPool.div(toBN(100)).mul(prizePercentages[0]))
+          .toString();
+
+      const isNewBalanceTwoValid =
+        newBalanceTwo.toString() ===
+        balanceTwo
+          .add(totalPool.div(toBN(100)).mul(prizePercentages[1]))
+          .toString();
+
+      expect(isNewBalanceOneValid).to.equal(true);
+      expect(isNewBalanceTwoValid).to.equal(true);
+
+      if (prizePercentages.length > 2) {
+        const isNewBalanceThreeValid =
+          newBalanceThree.toString() ===
+          balanceThree
+            .add(totalPool.div(toBN(100)).mul(prizePercentages[2]))
+            .toString();
+
+        expect(isNewBalanceThreeValid).to.equal(true);
+      }
+      if (prizePercentages.length > 3) {
+        const isNewBalanceFourValid =
+          newBalanceFour.toString() ===
+          balanceFour
+            .add(totalPool.div(toBN(100)).mul(prizePercentages[3]))
+            .toString();
+
+        expect(isNewBalanceFourValid).to.equal(true);
+      }
+    });
+
+    it("gives excess rewards to top 1 player if there are less players than the amount of top slots", async () => {
+      const prizePercentages = await pvpArena.getPrizePercentages();
+
+      const balanceOne = await skillToken.balanceOf(accounts[1]);
+      const balanceTwo = await skillToken.balanceOf(accounts[2]);
+
+      await pvpArena.distributeSeasonRewards({ from: accounts[0] });
+
+      await pvpArena.withdrawRankedRewards({ from: accounts[1] });
+      await pvpArena.withdrawRankedRewards({ from: accounts[2] });
+
+      const newBalanceOne = await skillToken.balanceOf(accounts[1]);
+      const newBalanceTwo = await skillToken.balanceOf(accounts[2]);
+
+      const expectedPlayerOneWithdrawal = newBalanceOne.sub(balanceOne);
+      const expectedPlayerTwoWithdrawal = newBalanceTwo.sub(balanceTwo);
+
+      const totalPool = expectedPlayerOneWithdrawal.add(
+        expectedPlayerTwoWithdrawal
+      );
+
+      let excessPrizePercentage = 0;
+
+      for (let i = 2; i < prizePercentages.length; i++) {
+        excessPrizePercentage = excessPrizePercentage + prizePercentages[i];
+      }
+
+      const isNewBalanceOneValid =
+        newBalanceOne.toString() ===
+        balanceOne
+          .add(
+            totalPool
+              .div(toBN(100))
+              .mul(prizePercentages[0].add(toBN(excessPrizePercentage)))
+          )
+          .toString();
+
+      const isNewBalanceTwoValid =
+        newBalanceTwo.toString() ===
+        balanceTwo
+          .add(totalPool.div(toBN(100)).mul(prizePercentages[1]))
+          .toString();
+
+      expect(isNewBalanceOneValid).to.equal(true);
+      expect(isNewBalanceTwoValid).to.equal(true);
     });
   });
 });

--- a/test/pvp-arena.js
+++ b/test/pvp-arena.js
@@ -76,11 +76,6 @@ contract("PvpArena", (accounts) => {
       accounts[4],
       web3.utils.toWei("1", "kether")
     );
-    await skillToken.transferFrom(
-      skillToken.address,
-      accounts[5],
-      web3.utils.toWei("1", "kether")
-    );
 
     await pvpArena.grantRole(await pvpArena.GAME_ADMIN(), accounts[0]);
     await characters.grantRole(await characters.GAME_ADMIN(), accounts[0]);

--- a/test/pvp-arena.js
+++ b/test/pvp-arena.js
@@ -2276,7 +2276,7 @@ contract("PvpArena", (accounts) => {
       let excessPrizePercentage = 0;
 
       for (let i = 2; i < prizePercentages.length; i++) {
-        excessPrizePercentage = excessPrizePercentage + prizePercentages[i];
+        excessPrizePercentage = +excessPrizePercentage + +prizePercentages[i];
       }
 
       const isNewBalanceOneValid =

--- a/test/pvp-arena.js
+++ b/test/pvp-arena.js
@@ -2147,7 +2147,7 @@ contract("PvpArena", (accounts) => {
     });
   });
 
-  describe.only("#distributeSeasonRewards", () => {
+  describe("#distributeSeasonRewards", () => {
     // These tests assume prizes will be distributed amongst at least 2 players and at most 4 players.
     beforeEach(async () => {
       character1ID = await createCharacterInPvpTier(accounts[1], 1);


### PR DESCRIPTION
This PR: 
- Implements seasonal rewards distribution functionality.
- Tests are designed to work with a minimum of 2 top positions to whom distribute rewards to:
  - This is done because there would not be a pool of rewards to distribute from if there was only 1 player (no duels).
- Tests are designed to work with a maximum of 4 top positions to whom distribute rewards to:
  - This is done because the current length of the top-ranking-players array is 4.
